### PR TITLE
split download set of commands into download and unarchive

### DIFF
--- a/src/setup-spark.ts
+++ b/src/setup-spark.ts
@@ -33,12 +33,13 @@ try {
   }
   
   var downloadCommand = `cd /tmp &&
-    wget -q -O ${path} ${sparkUrl}
+    wget -q -O ${path} ${sparkUrl} && ls /tmp
   `
 
   try {
     if (!fs.existsSync(path)) {
       try {
+        console.log(`${new Date().toLocaleTimeString('fr-FR')} - Downloading the binary from ${sparkUrl}`);
         execSync(downloadCommand);
       } catch (error) {
         console.log(`${new Date().toLocaleTimeString('fr-FR')} - Error running the command to download the Spark binary`);
@@ -55,7 +56,7 @@ try {
   tar xzf ${path} -C ${installFolder} &&
   ln -sf "${installFolder}/spark-${sparkVersion}-bin-hadoop${hadoopVersion}${scalaBit}" ${installFolder}/spark`
 
-  console.log(`${new Date().toLocaleTimeString('fr-FR')} - Downloading the binary from ${sparkUrl}`);
+  console.log(`${new Date().toLocaleTimeString('fr-FR')} - Unpacking the binary from ${path}`);
 
   try {
     execSync(command);

--- a/src/setup-spark.ts
+++ b/src/setup-spark.ts
@@ -10,7 +10,7 @@ try {
   const hadoopVersion = core.getInput('hadoop-version');
   const scalaVersion = core.getInput('scala-version');
   const py4jVersion = core.getInput('py4j-version');
-  const path = './spark.tgz'
+  const path = 'spark.tgz'
 
   // Try to write to the parent folder of the workflow workspace
   const workspaceFolder: string = process.env.GITHUB_WORKSPACE || '/home/runner/work'
@@ -32,14 +32,12 @@ try {
     sparkUrl = `https://archive.apache.org/dist/spark/spark-${sparkVersion}/spark-${sparkVersion}-bin-hadoop${hadoopVersion}${scalaBit}.tgz`
   }
   
-  var downloadCommand = `cd /tmp &&
-    wget -q -O ${path} ${sparkUrl} && ls /tmp
-  `
+  var downloadCommand = `cd /tmp && wget -q -O ${path} ${sparkUrl} && ls /tmp`
 
   try {
-    if (!fs.existsSync(path)) {
+    if (!fs.existsSync(`/tmp/${path}`)) {
       try {
-        console.log(`${new Date().toLocaleTimeString('fr-FR')} - Downloading the binary from ${sparkUrl}`);
+        console.log(`${new Date().toLocaleTimeString('fr-FR')} - Downloading the binary from ${sparkUrl} to /tmp/${path}`);
         execSync(downloadCommand);
       } catch (error) {
         console.log(`${new Date().toLocaleTimeString('fr-FR')} - Error running the command to download the Spark binary`);
@@ -56,12 +54,12 @@ try {
   tar xzf ${path} -C ${installFolder} &&
   ln -sf "${installFolder}/spark-${sparkVersion}-bin-hadoop${hadoopVersion}${scalaBit}" ${installFolder}/spark`
 
-  console.log(`${new Date().toLocaleTimeString('fr-FR')} - Unpacking the binary from ${path}`);
+  console.log(`${new Date().toLocaleTimeString('fr-FR')} - Unpacking the binary from /tmp/${path}`);
 
   try {
-    execSync(command);
+    execSync(untarCommand);
   } catch (error) {
-    console.log(`${new Date().toLocaleTimeString('fr-FR')} - Error running the command to download the Spark binary`);
+    console.log(`${new Date().toLocaleTimeString('fr-FR')} - Error running the command to unpack the Spark binary`);
     // @ts-ignore
     throw new Error(error.message);
   }


### PR DESCRIPTION
This allows to ues github actions for caching like so:

```
name: Caching

on: push

jobs:
  run:
    runs-on: ubuntu-latest

    steps:
    - uses: actions/checkout@v3

    - uses: actions/cache@v3
      with:
        path: /tmp/spark.tgz
        key: ${{ runner.os }}-spark

    - uses: vemonet/setup-spark@v1
      with:
        spark-version: 3.3.2
        hadoop-version: 3

```